### PR TITLE
Add a step for caching node_modules

### DIFF
--- a/.github/workflows/test-npm-run.yml
+++ b/.github/workflows/test-npm-run.yml
@@ -31,7 +31,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
           scope: "@worldcoin"
           directory: './'
-          command: node -v # Just log node version
+          command: npm list # List package dependencies (fails if node_modules folder missing)
         env:
           CI: true
           NODE_AUTH_TOKEN: SURPRISE

--- a/npm-run/action.yml
+++ b/npm-run/action.yml
@@ -29,13 +29,20 @@ runs:
       with:
         fetch-depth: 0
         ref: ${{ inputs.ref }}
+    - name: Cache node_modules
+      id: cache-npm
+      uses: actions/cache@v3
+      with:
+        key: ${{ hashFiles( format('{0}/{1}', inputs.directory, 'package-lock.json') ) }}
+        path: ${{ inputs.directory }}/node_modules
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.scope }}
-    - name: Install
+    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      name: Install
       run: |
         cd ${{ inputs.directory }}
         npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "github-actions",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-actions",
+      "version": "0.0.1",
+      "license": "NA"
+    }
+  }
+}


### PR DESCRIPTION
Closes PLA-121.

I've added the cache action, but excluded cache input in setup-node. The former just caches tarballs for each package, thus reducing network load but still keeping requirement for install step. In addition when keys for caching are identical in cache and setup-node actions, then cache hit conditions are identical - a cache miss would trigger both redownload and reinstallation of the deps.

NOTE: Every version bump changes the `package-lock.json` and thus makes a cache miss. Hence caching won't be effective for checks on version update commits. Even though non-version update commits (e.g. checks within a single PR) would take advantage of the caching.