### PR TITLE
Update github-script and actions/checkout actions to the latest versions

### DIFF
--- a/.github/workflows/test-create-release.yml
+++ b/.github/workflows/test-create-release.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # The previous action fails to find a draft release.
       # Thus need to delete it manually with octokit.
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         env:
           RELEASE_ID: ${{ steps.create-release.outputs.release-id }}
         with:
@@ -46,7 +46,7 @@ jobs:
             const release_id = process.env.RELEASE_ID
             const { owner, repo } = context.repo
             try {
-              await github.repos.deleteRelease({ owner, repo, release_id })
+              await github.rest.repos.deleteRelease({ owner, repo, release_id })
               console.log(`✅  Release "${release_id}" deleted successfully!`)
             } catch (e) {
               console.error(e)

--- a/.github/workflows/test-create-release.yml
+++ b/.github/workflows/test-create-release.yml
@@ -9,6 +9,7 @@ on:
       - create-release/**
       - .github/workflows/test-create-release.yml
   push:
+    branches: main
     paths:
       - create-release/**
       - .github/workflows/test-create-release.yml

--- a/.github/workflows/test-latest-release-commit-hash.yml
+++ b/.github/workflows/test-latest-release-commit-hash.yml
@@ -9,6 +9,7 @@ on:
       - latest-release-commit-hash/**
       - .github/workflows/test-latest-release-commit-hash.yml
   push:
+    branches: main
     paths: 
       - latest-release-commit-hash/**
       - .github/workflows/test-latest-release-commit-hash.yml

--- a/.github/workflows/test-npm-run.yml
+++ b/.github/workflows/test-npm-run.yml
@@ -9,6 +9,7 @@ on:
       - npm-run/**
       - .github/workflows/test-npm-run.yml
   push:
+    branches: main
     paths: 
       - npm-run/**
       - .github/workflows/test-npm-run.yml

--- a/.github/workflows/test-publish-npm.yml
+++ b/.github/workflows/test-publish-npm.yml
@@ -9,6 +9,7 @@ on:
       - publish-npm/**
       - .github/workflows/test-publish-npm.yml
   push:
+    branches: main
     paths: 
       - publish-npm/**
       - .github/workflows/test-publish-npm.yml

--- a/generate-db-diagram/action.yml
+++ b/generate-db-diagram/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Fetch mermerd


### PR DESCRIPTION
The previous versions use Node@12 which is being deprecation and thus causes warnings. The latest versions are updated to Node@16.

Closes PLA-136.